### PR TITLE
Fix for temp directory config not being used

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Furthermore, if you'd like to try out a fun sample, clone the [Rock Paper Scisso
 
 After you install the CodeSwing extension, you can create new swings at any time, using the following commands:
 
-- `CodeSwing: New Swing...` - Creates a temporary "scratch" swing, that allows you to quickly try something out (like a visual REPL!). These swings are stored in your system temp directory in a folder called `codeswing`, and are named based on the current date/time. If you'd like to customize where scratch swings are stored, you can set the `CodeSwing: Scratch Directory` setting to the absolute path of the desired directory.
+- `CodeSwing: New Swing...` - Creates a temporary swing that allows you to quickly try something out (like a visual REPL!). These swings are stored in your system temp directory in a folder called `codeswing`, and are named based on the current date/time. If you'd like to customize where these swings are stored, you can set the `Temp Directory` setting in the extension preferences to the absolute path of the desired directory.
 
 - `CodeSwing: New Swing from Last Template` - Creates a swing using the last template that you used. This can be useful when you tend to use the same template over and over again.
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -10,7 +10,7 @@ export function get(
 export function get(
   key: "readmeBehavior"
 ): "none" | "previewFooter" | "previewHeader";
-export function get(key: "scratchDirectory"): string;
+export function get(key: "tempDirectory"): string;
 export function get(key: "showConsole"): boolean;
 export function get(key: "templateGalleries"): string[];
 export function get(key: any) {

--- a/src/creation/index.ts
+++ b/src/creation/index.ts
@@ -24,7 +24,7 @@ interface CodeSwingTemplateItem extends vscode.QuickPickItem {
 
 async function createSwingDirectory() {
   const scratchDirectory =
-          config.get("scratchDirectory") ||
+          config.get("tempDirectory") ||
           path.join(os.tmpdir(), EXTENSION_NAME);
   const dayjs = require("dayjs");
   const timestamp = dayjs().format("YYYY-MM-DD (hh-mm-ss A)");


### PR DESCRIPTION
The config that stored the temporary directory was internally called `scratchDirectory` vs `tempDirectory` in the actual preferences, so it doesn't work when setting it through the extension settings. This PR fixes this issue.