### PR TITLE
use webpack `raw-loader` for css stylesheet

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "codeswing",
-  "version": "0.0.18",
+  "version": "0.0.19",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -3236,6 +3236,38 @@
       "dev": true,
       "requires": {
         "safe-buffer": "^5.1.0"
+      }
+    },
+    "raw-loader": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/raw-loader/-/raw-loader-4.0.2.tgz",
+      "integrity": "sha512-ZnScIV3ag9A4wPX/ZayxL/jZH+euYb6FcUinPcgiQW0+UBtEv0O6Q3lGd3cqJ+GHH+rksEv3Pj99oxJ3u3VIKA==",
+      "dev": true,
+      "requires": {
+        "loader-utils": "^2.0.0",
+        "schema-utils": "^3.0.0"
+      },
+      "dependencies": {
+        "json5": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.0.tgz",
+          "integrity": "sha512-f+8cldu7X/y7RAJurMEJmdoKXGB/X550w2Nr3tTbezL6RwEE/iMcm+tZnXeoZtKuOq6ft8+CqzEkrIgx1fPoQA==",
+          "dev": true,
+          "requires": {
+            "minimist": "^1.2.5"
+          }
+        },
+        "loader-utils": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.0.tgz",
+          "integrity": "sha512-rP4F0h2RaWSvPEkD7BLDFQnvSf+nK+wr3ESUjNTyAGobqrijmW92zc+SO6d4p4B1wh7+B/Jg1mkQe5NYUEHtHQ==",
+          "dev": true,
+          "requires": {
+            "big.js": "^5.2.2",
+            "emojis-list": "^3.0.0",
+            "json5": "^2.1.2"
+          }
+        }
       }
     },
     "read": {

--- a/package.json
+++ b/package.json
@@ -407,6 +407,7 @@
     "@typescript-eslint/parser": "^4.1.1",
     "eslint": "^7.9.0",
     "glob": "^7.1.6",
+    "raw-loader": "^4.0.2",
     "ts-loader": "^8.0.12",
     "typescript": "^4.1.2",
     "vsce": "^1.95.0",

--- a/src/preview/stylesheets/stylesheets.d.ts
+++ b/src/preview/stylesheets/stylesheets.d.ts
@@ -1,0 +1,4 @@
+declare module "raw-loader!*" {
+	const value: string;
+	export default value;
+}

--- a/src/preview/stylesheets/themeStyles.css
+++ b/src/preview/stylesheets/themeStyles.css
@@ -1,4 +1,3 @@
-const styles = `
 *:focus {
   outline: var(--vscode-focusBorder) solid 1px;
 }
@@ -153,6 +152,3 @@ kbd {
 kbd + kbd {
   margin-left: 4px;
 }
-`
-
-export default styles

--- a/src/preview/webview.ts
+++ b/src/preview/webview.ts
@@ -1,4 +1,5 @@
 import axios from "axios";
+import themeStyles from "raw-loader!./stylesheets/themeStyles.css";
 import * as vscode from "vscode";
 import { openSwing } from ".";
 import * as config from "../config";
@@ -8,7 +9,6 @@ import { byteArrayToString } from "../utils";
 import { getScriptContent } from "./languages/script";
 import { getCDNJSLibraries } from "./libraries/cdnjs";
 import { ProxyFileSystemProvider } from "./proxyFileSystemProvider";
-import themeStyles from "./themeStyles";
 import { storage } from "./tutorials/storage";
 
 const EXIT_RESPONSE = "Exit Swing";


### PR DESCRIPTION
**Feel free to reject this PR, I'm not easy to offend and you've been very patient w/ me so far!**

This PR is a no-op as far as the final packaged code is concerned. But (I think) it offers a minor improvement in terms of developer experience and maintainability (and also it's kind of a cool nifty little webpack trick).

Context:
- webpack has a `raw-loader` to import any file as a string
- any import statement can declare *inline* which loader to use with the following syntax
    ```js
    import txt from 'raw-loader!./file.txt';
    ```
- the themeStyles stylesheet is meant to be used as a string, but is easier to author / read / maintain as a css file

Changes:
- `themeStyles.ts` becomes `themeStyles.css` which makes it more clear what this file is from just its name, and allows VSCode to apply CSS syntax highlighting automatically;
- `webview.ts` imports `themeStyles.css` as a string and the rest is the same as before.



