### PR TITLE
remove web extension kind

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
     "url": "https://github.com/codespaces-contrib/codeswing"
   },
   "extensionKind": [
-    "web",
     "ui",
     "workspace"
   ],


### PR DESCRIPTION
Hi, this is developer from VS Code. As we are rolling out web extensions we are trying to fine tune and simplify the concepts around web extensions. As a result, we are no longer supporting web as an extension kind to identify as a web extension. Instead we infer it from other properties - See https://github.com/microsoft/vscode-docs/blob/vnext/api/extension-guides/web-extensions.md#web-extension-enablement for more details. With latest vsce, it will validate extension kind for appropriate values which are `ui`, `workspace`. Since this extension has `web` extension kind, this PR fixes it properly.

This PR removes web extension kind from the package.json. As a result, **In a web codespace with server, this extension runs on the server.** 