### PR TITLE
Fixed imports when scriptType is module in codeswing.json

### DIFF
--- a/src/preview/languages/script.ts
+++ b/src/preview/languages/script.ts
@@ -54,6 +54,8 @@ export function getScriptContent(
   const content = document.getText();
   if (content.trim() === "") {
     return [content, isModule];
+  } else if (manifest?.scriptType === 'module') {
+    isModule = true;
   } else {
     isModule = isModule || content.trim().startsWith("import ");
   }

--- a/src/preview/webview.ts
+++ b/src/preview/webview.ts
@@ -301,9 +301,7 @@ export class SwingWebView {
 
     const scriptType = this.isJavaScriptModule
       ? "module"
-      : this.manifest && this.manifest.scriptType
-      ? this.manifest.scriptType
-      : "text/javascript";
+      : (this.manifest?.scriptType || "text/javascript");
 
     const readmeBehavior =
       (this.manifest && this.manifest.readmeBehavior) ||


### PR DESCRIPTION
This fixes an issue with scripts that rely on ESM were not working.

In case when a file has extension `.js` and `scriptType` is set to `"module"` in codeswing.json, before `import` statements were not replaced to use CDNJS (some heuristic was in place to make them work anyways if the file began with `import `, but not if the file didn't - such as if it started with a comment)