### PR TITLE
Fix #89: Update webview panel's title to reflect document's title changes

### DIFF
--- a/src/preview/webview.ts
+++ b/src/preview/webview.ts
@@ -157,6 +157,12 @@ export class SwingWebView {
           }
           break;
         }
+
+        case "updateTitle": {
+          const title = value;
+          store.activeSwing!.webViewPanel.title = `CodeSwing (${title})`;
+          break;
+        }
       }
     });
   }
@@ -378,6 +384,7 @@ export class SwingWebView {
   <head>
     <base href="${baseUrl}" />
     <meta charset="UTF-8" />
+    <title>CodeSwing</title>
     <style>
 
       html, body {
@@ -426,6 +433,14 @@ export class SwingWebView {
         if (linkedScript) {
           linkedScript.parentElement.removeChild(linkedScript);
         }
+
+        const observer = new MutationObserver(() => {
+          vscode.postMessage({
+            command: "updateTitle",
+            value: document.title
+          });
+        });
+        observer.observe(document.querySelector("title"), { attributes: true, childList: true, subtree: true });
       });
   
       let httpRequestId = 1;


### PR DESCRIPTION
Fixes #89

Update webview panel's title to reflect document's title changes

This PR was created with Copilot Workspace (v0.14). For more details, open the [Copilot Workspace session](https://copilot-workspace-dev.githubnext.com/lostintangent/codeswing/issues/89?shareId=b6aca36f-bcd1-49e4-a6f7-d8a895550c3f).