### PR TITLE
Add support for Vue 3 component based swings

### DIFF
--- a/package.json
+++ b/package.json
@@ -464,7 +464,6 @@
     "@types/glob": "^7.1.3",
     "@types/node": "^12.11.7",
     "@types/sass": "^1.16.1",
-    "@types/vscode": "^1.75.0",
     "@typescript-eslint/eslint-plugin": "^4.1.1",
     "@typescript-eslint/parser": "^4.1.1",
     "eslint": "^7.9.0",
@@ -479,7 +478,8 @@
   },
   "dependencies": {
     "@azure/openai": "^1.0.0-beta.11",
-    "@vue/component-compiler": "^4.2.3",
+    "@babel/standalone": "^7.16.5",
+    "@vue/compiler-sfc": "^3.2.26",
     "axios": "^1.6.7",
     "case": "^1.6.3",
     "dayjs": "^1.11.10",

--- a/src/preview/languages/components/vue.ts
+++ b/src/preview/languages/components/vue.ts
@@ -1,4 +1,5 @@
-import { assemble, createDefaultCompiler } from "@vue/component-compiler";
+import { parse, compileTemplate, compileScript } from "@vue/compiler-sfc";
+import { transform } from "@babel/standalone";
 
 const APP_INIT = `new Vue({
     el: "#app",
@@ -6,11 +7,13 @@ const APP_INIT = `new Vue({
 });`
 
 const COMPONENT_NAME = "index.vue";
-const compiler = createDefaultCompiler();
 
 export function compileComponent(content: string): [string, string, [string, string][]] {
-    const descriptor = compiler.compileToDescriptor(COMPONENT_NAME, content);
-    const { code } = assemble(compiler, COMPONENT_NAME, descriptor, {});
-
-    return [code, APP_INIT, [["Vue", "vue"]]];
+    const { descriptor } = parse(content, { filename: COMPONENT_NAME });
+    const { code: templateCode } = compileTemplate({ source: descriptor.template.content, filename: COMPONENT_NAME });
+    const { content: scriptContent, lang } = descriptor.scriptSetup || descriptor.script || { content: "", lang: "js" };
+    const { code: scriptCode } = compileScript(descriptor, { id: COMPONENT_NAME });
+    const script = lang === "js" ? scriptCode : transform(scriptCode, { filename: COMPONENT_NAME, presets: [lang] }).code;
+    const styleVars = descriptor.styles.some(style => style.attrs.vars) ? "vue-style-vars" : "";
+    return [templateCode + "\n" + script, APP_INIT, [["Vue", "vue"], [styleVars, styleVars]]];
 }


### PR DESCRIPTION
This PR introduces support for Vue 3 component-based swings 🥳 

---

For more details, open the [Copilot Workspace session](https://copilot-workspace-dev.githubnext.com/lostintangent/codeswing?shareId=bbdb6977-9abf-436a-8d72-4c8199a508ee).