### PR TITLE
Add 'New Swing in New Window' command

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ After you install the CodeSwing extension, you can create new swings at any time
 
 - `CodeSwing: New Swing in Directory...` - Creates a swing in a local directory, which allows you to re-open it later, and easily share it with others (e.g. store it in a GitHub repo).
 
+- `CodeSwing: New Swing in New Window...` - Creates a new temporary swing in a new VS Code window.
+
 After creating a swing, your editor layout will be automatically setup to accomodate the needs of the selected template. Furthermore, if you open a directory that represents a swing, or you run the `CodeSwing: Open Swing...` command, then the selected swing will be automatically launched.
 
 ### Language Support
@@ -264,6 +266,8 @@ When you install CodeSwing, the following commands are available from the comman
 - `CodeSwing: Open Swing...` - Opens a swing, based on the contents of a specified directory.
 
 - `CodeSwing: Open Swing in New Windows...` - Opens a swing in a new VS Code window.
+
+- `CodeSwing: New Swing in New Window...` - Creates a new temporary swing in a new VS Code window.
 
 - `CodeSwing: Set OpenAI API Key` - Configures the OpenAI API key that is used to support generating AI swings.
 

--- a/package.json
+++ b/package.json
@@ -140,6 +140,11 @@
         "command": "codeswing.uploadSwingFile",
         "title": "Upload File(s)",
         "icon": "$(cloud-upload)"
+      },
+      {
+        "command": "codeswing.newSwingInNewWindow",
+        "title": "New Swing in New Window...",
+        "category": "CodeSwing"
       }
     ],
     "views": {


### PR DESCRIPTION
Fixes #97

Add a new command "New Swing in New Window" to create a new swing in a new VS Code window.

* **package.json**:
  - Add a new command `codeswing.newSwingInNewWindow` with the title "New Swing in New Window..." under `contributes.commands`.

* **src/creation/index.ts**:
  - Add a new command `codeswing.newSwingInNewWindow` that creates a new temporary directory for the swing and opens it in a new VS Code window.
  - Update the `newSwing` and `newSwingFromTemplate` functions to allow specifying an optional boolean parameter to open the URI in a new VS Code window.

* **README.md**:
  - Add the new command `codeswing.newSwingInNewWindow` to the list of available commands.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/lostintangent/codeswing/issues/97?shareId=4e9cd896-acf5-478a-931d-75a6acf4dfbc).