### PR TITLE
Add new swing in new window command

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ After you install the CodeSwing extension, you can create new swings at any time
 
 - `CodeSwing: New Swing in Directory...` - Creates a swing in a local directory, which allows you to re-open it later, and easily share it with others (e.g. store it in a GitHub repo).
 
+- `CodeSwing: New Swing in New Window` - Creates a new temporary swing in a new VS Code window. This can be useful when you want to create a swing without affecting your current workspace.
+
 After creating a swing, your editor layout will be automatically setup to accomodate the needs of the selected template. Furthermore, if you open a directory that represents a swing, or you run the `CodeSwing: Open Swing...` command, then the selected swing will be automatically launched.
 
 ### Language Support
@@ -266,6 +268,8 @@ When you install CodeSwing, the following commands are available from the comman
 - `CodeSwing: Open Swing in New Windows...` - Opens a swing in a new VS Code window.
 
 - `CodeSwing: Set OpenAI API Key` - Configures the OpenAI API key that is used to support generating AI swings.
+
+- `CodeSwing: New Swing in New Window` - Creates a new temporary swing in a new VS Code window. This can be useful when you want to create a swing without affecting your current workspace.
 
 Additionally, when you have a swing currently open, the following commands are available:
 

--- a/package.json
+++ b/package.json
@@ -80,6 +80,11 @@
         "category": "CodeSwing"
       },
       {
+        "command": "codeswing.newSwingInNewWindow",
+        "title": "New Swing in New Window",
+        "category": "CodeSwing"
+      },
+      {
         "command": "codeswing.openConsole",
         "title": "Open Console",
         "category": "CodeSwing",

--- a/src/creation/index.ts
+++ b/src/creation/index.ts
@@ -226,6 +226,14 @@ async function promptForGalleryConfiguration(
   quickPick.show();
 }
 
+async function newSwingInNewWindow() {
+  const swingUri = await createSwingDirectory();
+  await newSwing(swingUri);
+  await vscode.commands.executeCommand("vscode.openFolder", swingUri, {
+    forceNewWindow: true,
+  });
+}
+
 export function registerCreationModule(
   context: vscode.ExtensionContext,
   api: any,
@@ -316,6 +324,13 @@ export function registerCreationModule(
           );
         });
       }
+    )
+  );
+
+  context.subscriptions.push(
+    vscode.commands.registerCommand(
+      `${EXTENSION_NAME}.newSwingInNewWindow`,
+      newSwingInNewWindow
     )
   );
 


### PR DESCRIPTION
Related to #97

Add a new command "New Swing in New Window" to create a new swing in a new VS Code window.

* **package.json**
  - Add a new command `codeswing.newSwingInNewWindow` with the title "New Swing in New Window".

* **src/creation/index.ts**
  - Implement the `newSwingInNewWindow` function to create a new temporary directory for the swing.
  - Prompt the user with the existing "new swing" flow.
  - Open the new swing in a new VS Code window.
  - Register the new command to call the `newSwingInNewWindow` function.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/lostintangent/codeswing/issues/97?shareId=4d2dd4a8-a66e-45fb-aea1-0c89dbf461cf).